### PR TITLE
fix: Images not loading

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,13 @@ const options = {
 }
 
 const response = await fetch(url, options)
-const { data } = await response.json()
+var { data } = await response.json()
+
+// Append API_TOKEN to the "image" key in each element of the "data" array
+data = data.map(item => ({
+  ...item,
+  image: item.image + "?rapidapi-key=" + API_TOKEN
+}));
 ---
 
 <Layout title="World Padel Tour ">


### PR DESCRIPTION
Hi @thelucho,
I've found why images are not loading in the web app. It's because the API key is not being sent in the URL.

**Changes Proposed**:
- I've made changes to the codebase to ensure that the API key is included in the URL when fetching images from our API.

I've tested these changes thoroughly to confirm that images now load correctly and that the API key is included as expected.

Let me know if you have any questions or concerns.